### PR TITLE
fix: resolve missing ui modules and types

### DIFF
--- a/src/components/LegalToolkitPro.tsx
+++ b/src/components/LegalToolkitPro.tsx
@@ -5,10 +5,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
-import { Copy, Download, FileText, IdCard, Printer, RefreshCw } from "lucide-react";
+import { Copy, Download, FileText, Contact, Printer, RefreshCw } from "lucide-react";
 import { toPng } from "html-to-image";
 import jsPDF from "jspdf";
 import { PricingPlans } from "@/components/PricingPlans";
@@ -218,61 +217,128 @@ export default function LegalToolkitPro(){
           <div className="grid gap-4 md:grid-cols-3">
             <div>
               <Label>Document Type</Label>
-              <Select value={state.documentType} onValueChange={(v)=>dispatch({type:"set", key:"documentType", value:v})}>
-                <SelectTrigger className="mt-1"><SelectValue placeholder="Choose"/></SelectTrigger>
-                <SelectContent>
-                  {DocType.options.map((t)=> (<SelectItem key={t} value={t}>{t}</SelectItem>))}
-                </SelectContent>
-              </Select>
+              <select
+                className="mt-1 w-full rounded-md border px-2 py-2 text-sm"
+                value={state.documentType}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  dispatch({ type: "set", key: "documentType", value: e.target.value as DocType })
+                }
+              >
+                <option value="" disabled>Choose</option>
+                {DocType.options.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
             </div>
             <div>
               <Label>State</Label>
-              <Select value={state.selectedState as string} onValueChange={(v)=>dispatch({type:"set", key:"selectedState", value:v})}>
-                <SelectTrigger className="mt-1"><SelectValue placeholder="Select a state"/></SelectTrigger>
-                <SelectContent className="max-h-72">
-                  {["", ...ALL_STATES].map((c)=> (<SelectItem key={c || "none"} value={c as string}>{c || "—"}</SelectItem>))}
-                </SelectContent>
-              </Select>
+              <select
+                className="mt-1 w-full rounded-md border px-2 py-2 text-sm"
+                value={state.selectedState as string}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  dispatch({ type: "set", key: "selectedState", value: e.target.value })
+                }
+              >
+                <option value="">—</option>
+                {ALL_STATES.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
             </div>
             <div>
               <Label>Agency / Recipient</Label>
-              <Input className="mt-1" value={state.agency} onChange={(e)=>dispatch({type:"set", key:"agency", value:e.target.value})} placeholder="e.g., City Clerk / Records Custodian"/>
+              <Input
+                className="mt-1"
+                value={state.agency}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  dispatch({ type: "set", key: "agency", value: e.target.value })
+                }
+                placeholder="e.g., City Clerk / Records Custodian"
+              />
             </div>
           </div>
 
           <div className="grid gap-4 md:grid-cols-3">
             <div>
               <Label>Jurisdiction</Label>
-              <Input className="mt-1" value={state.jurisdiction} onChange={(e)=>dispatch({type:"set", key:"jurisdiction", value:e.target.value})} placeholder="Auto‑filled by state"/>
+              <Input
+                className="mt-1"
+                value={state.jurisdiction}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  dispatch({ type: "set", key: "jurisdiction", value: e.target.value })
+                }
+                placeholder="Auto‑filled by state"
+              />
             </div>
             <div>
               <Label>Statute</Label>
-              <Input className="mt-1" value={state.statute} onChange={(e)=>dispatch({type:"set", key:"statute", value:e.target.value})} placeholder="Auto‑filled by doc type"/>
+              <Input
+                className="mt-1"
+                value={state.statute}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  dispatch({ type: "set", key: "statute", value: e.target.value })
+                }
+                placeholder="Auto‑filled by doc type"
+              />
             </div>
             <div>
               <Label>Time Limit</Label>
-              <Input className="mt-1" value={state.timeLimit} onChange={(e)=>dispatch({type:"set", key:"timeLimit", value:e.target.value})} placeholder="Auto‑filled by doc type"/>
+              <Input
+                className="mt-1"
+                value={state.timeLimit}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  dispatch({ type: "set", key: "timeLimit", value: e.target.value })
+                }
+                placeholder="Auto‑filled by doc type"
+              />
             </div>
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">
             <div>
               <Label>Subject / Incident</Label>
-              <Textarea className="mt-1" rows={5} value={state.incident} onChange={(e)=>dispatch({type:"set", key:"incident", value:e.target.value})} placeholder="Describe records sought or facts (who/what/when/where)"/>
+              <Textarea
+                className="mt-1"
+                rows={5}
+                value={state.incident}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  dispatch({ type: "set", key: "incident", value: e.target.value })
+                }
+                placeholder="Describe records sought or facts (who/what/when/where)"
+              />
             </div>
             <div className="space-y-4">
               <div>
                 <Label>Violation Type (Cease & Desist)</Label>
-                <Select value={state.violationType} onValueChange={(v)=>dispatch({type:"set", key:"violationType", value:v})}>
-                  <SelectTrigger className="mt-1"><SelectValue/></SelectTrigger>
-                  <SelectContent>
-                    {["harassment","intellectual_property","debt_collection","trespass","defamation","contract","privacy"].map((t)=> (<SelectItem key={t} value={t}>{t.replaceAll("_"," ")}</SelectItem>))}
-                  </SelectContent>
-                </Select>
+                <select
+                  className="mt-1 w-full rounded-md border px-2 py-2 text-sm"
+                  value={state.violationType}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                    dispatch({ type: "set", key: "violationType", value: e.target.value as FormState["violationType"] })
+                  }
+                >
+                  {["harassment","intellectual_property","debt_collection","trespass","defamation","contract","privacy"].map((t) => (
+                    <option key={t} value={t}>
+                      {t.replaceAll("_", " ")}
+                    </option>
+                  ))}
+                </select>
               </div>
               <div>
                 <Label>Damages (optional)</Label>
-                <Textarea className="mt-1" rows={3} value={state.damages} onChange={(e)=>dispatch({type:"set", key:"damages", value:e.target.value})} placeholder="Monetary damages, reputational harm, etc."/>
+                <Textarea
+                  className="mt-1"
+                  rows={3}
+                  value={state.damages}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                    dispatch({ type: "set", key: "damages", value: e.target.value })
+                  }
+                  placeholder="Monetary damages, reputational harm, etc."
+                />
               </div>
             </div>
           </div>
@@ -285,36 +351,69 @@ export default function LegalToolkitPro(){
             <TabsContent value="parties" className="grid gap-4 md:grid-cols-3">
               <div>
                 <Label>Plaintiff</Label>
-                <Input className="mt-1" value={state.plaintiffName} onChange={(e)=>dispatch({type:"set", key:"plaintiffName", value:e.target.value})}/>
+                <Input
+                  className="mt-1"
+                  value={state.plaintiffName}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    dispatch({ type: "set", key: "plaintiffName", value: e.target.value })
+                  }
+                />
               </div>
               <div>
                 <Label>Defendant</Label>
-                <Input className="mt-1" value={state.defendantName} onChange={(e)=>dispatch({type:"set", key:"defendantName", value:e.target.value})}/>
+                <Input
+                  className="mt-1"
+                  value={state.defendantName}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    dispatch({ type: "set", key: "defendantName", value: e.target.value })
+                  }
+                />
               </div>
               <div>
                 <Label>Recipient (for C&D/Subpoena)</Label>
-                <Input className="mt-1" value={state.recipient} onChange={(e)=>dispatch({type:"set", key:"recipient", value:e.target.value})}/>
+                <Input
+                  className="mt-1"
+                  value={state.recipient}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    dispatch({ type: "set", key: "recipient", value: e.target.value })
+                  }
+                />
               </div>
             </TabsContent>
             <TabsContent value="case" className="grid gap-4 md:grid-cols-3">
               <div>
                 <Label>Claim Type</Label>
-                <Select value={state.claimType} onValueChange={(v)=>dispatch({type:"set", key:"claimType", value:v})}>
-                  <SelectTrigger className="mt-1"><SelectValue/></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="general">General</SelectItem>
-                    <SelectItem value="government">Government Tort</SelectItem>
-                    <SelectItem value="medical">Medical</SelectItem>
-                  </SelectContent>
-                </Select>
+                <select
+                  className="mt-1 w-full rounded-md border px-2 py-2 text-sm"
+                  value={state.claimType}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                    dispatch({ type: "set", key: "claimType", value: e.target.value as FormState["claimType"] })
+                  }
+                >
+                  <option value="general">General</option>
+                  <option value="government">Government Tort</option>
+                  <option value="medical">Medical</option>
+                </select>
               </div>
               <div>
                 <Label>Case Number</Label>
-                <Input className="mt-1" value={state.caseNumber} onChange={(e)=>dispatch({type:"set", key:"caseNumber", value:e.target.value})}/>
+                <Input
+                  className="mt-1"
+                  value={state.caseNumber}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    dispatch({ type: "set", key: "caseNumber", value: e.target.value })
+                  }
+                />
               </div>
               <div>
                 <Label>Court Name</Label>
-                <Input className="mt-1" value={state.courtName} onChange={(e)=>dispatch({type:"set", key:"courtName", value:e.target.value})}/>
+                <Input
+                  className="mt-1"
+                  value={state.courtName}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    dispatch({ type: "set", key: "courtName", value: e.target.value })
+                  }
+                />
               </div>
             </TabsContent>
           </Tabs>
@@ -378,7 +477,13 @@ export default function LegalToolkitPro(){
                 </div>
               </div>
             ) : (
-              <Textarea className="min-h-[300px]" value={state.generated} onChange={(e)=>dispatch({type:"generate", value:e.target.value})}/>
+              <Textarea
+                className="min-h-[300px]"
+                value={state.generated}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  dispatch({ type: "generate", value: e.target.value })
+                }
+              />
             )}
           </CardContent>
         </Card>
@@ -390,7 +495,7 @@ export default function LegalToolkitPro(){
               <Button variant="outline" onClick={()=>copyToClipboard(state.generated)} disabled={state.documentType === "ID Rights Card" && !state.generated}><Copy className="mr-2 h-4 w-4"/>Copy Text</Button>
               <Button variant="outline" onClick={()=>downloadText(`${state.documentType.replaceAll(" ", "-").toLowerCase()}.txt`, state.generated)} disabled={state.documentType === "ID Rights Card" && !state.generated}><Download className="mr-2 h-4 w-4"/>Download .txt</Button>
               {state.documentType === "ID Rights Card" && (<>
-                <Button onClick={exportIdCardPNG}><IdCard className="mr-2 h-4 w-4"/>Export PNG</Button>
+                <Button onClick={exportIdCardPNG}><Contact className="mr-2 h-4 w-4"/>Export PNG</Button>
                 <Button onClick={exportIdCardPDF}><Printer className="mr-2 h-4 w-4"/>Export PDF</Button>
               </>)}
             </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export type BadgeProps = React.HTMLAttributes<HTMLSpanElement> & {
+  variant?: "default" | "secondary" | "outline";
+};
+
+export const Badge: React.FC<BadgeProps> = ({ className = "", variant = "default", ...props }) => {
+  const base = "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold";
+  const variants: Record<string, string> = {
+    default: "bg-muted text-foreground",
+    secondary: "bg-secondary text-secondary-foreground",
+    outline: "text-foreground",
+  };
+  return <span className={`${base} ${variants[variant]} ${className}`.trim()} {...props} />;
+};

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "default" | "secondary" | "outline";
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = "", variant = "default", ...props }, ref) => {
+    const base = "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium focus:outline-none";
+    const variants: Record<string, string> = {
+      default: "bg-primary text-white hover:bg-primary/90",
+      secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+      outline: "border bg-transparent hover:bg-accent",
+    };
+    return (
+      <button
+        ref={ref}
+        className={`${base} ${variants[variant]} ${className}`.trim()}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export const Card: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ className = "", ...props }) => (
+  <div className={`rounded-lg border bg-card text-card-foreground shadow-sm ${className}`.trim()} {...props} />
+);
+
+export const CardHeader: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ className = "", ...props }) => (
+  <div className={`p-6 ${className}`.trim()} {...props} />
+);
+
+export const CardTitle: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = ({ className = "", ...props }) => (
+  <h3 className={`text-2xl font-semibold leading-none tracking-tight ${className}`.trim()} {...props} />
+);
+
+export const CardContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ className = "", ...props }) => (
+  <div className={`p-6 pt-0 ${className}`.trim()} {...props} />
+);

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className = "", ...props }, ref) => (
+    <input
+      ref={ref}
+      className={`flex h-10 w-full rounded-md border px-3 py-2 text-sm ${className}`.trim()}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const Label: React.FC<React.LabelHTMLAttributes<HTMLLabelElement>> = ({ className = "", ...props }) => (
+  <label className={`text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 ${className}`.trim()} {...props} />
+);

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+interface TabsContextValue {
+  value: string;
+  setValue: (v: string) => void;
+}
+const TabsContext = React.createContext<TabsContextValue | undefined>(undefined);
+
+export const Tabs: React.FC<{ defaultValue: string; children: React.ReactNode }> = ({ defaultValue, children }) => {
+  const [value, setValue] = React.useState(defaultValue);
+  return <TabsContext.Provider value={{ value, setValue }}>{children}</TabsContext.Provider>;
+};
+
+export const TabsList: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ className = "", ...props }) => (
+  <div className={`flex border-b ${className}`.trim()} {...props} />
+);
+
+export const TabsTrigger: React.FC<{ value: string } & React.ButtonHTMLAttributes<HTMLButtonElement>> = ({ value, className = "", ...props }) => {
+  const ctx = React.useContext(TabsContext);
+  if (!ctx) throw new Error("TabsTrigger must be used within Tabs");
+  const active = ctx.value === value;
+  return (
+    <button
+      className={`px-2 py-1 text-sm ${active ? "font-semibold" : "text-muted-foreground"} ${className}`.trim()}
+      onClick={() => ctx.setValue(value)}
+      {...props}
+    />
+  );
+};
+
+export const TabsContent: React.FC<{ value: string } & React.HTMLAttributes<HTMLDivElement>> = ({ value, className = "", ...props }) => {
+  const ctx = React.useContext(TabsContext);
+  if (!ctx || ctx.value !== value) return null;
+  return <div className={className} {...props} />;
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  ({ className = "", ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={`w-full rounded-md border px-3 py-2 text-sm ${className}`.trim()}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = "Textarea";


### PR DESCRIPTION
## Summary
- replace missing UI library with minimal components
- switch legal toolkit selects to native elements and add type annotations
- use existing Contact icon for ID card export

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c374d92f508330bccf5321c7c6cea7